### PR TITLE
Changed two files to actually use the CSS.

### DIFF
--- a/src/fountain.cc
+++ b/src/fountain.cc
@@ -866,7 +866,7 @@ std::string ftn2screenplain(std::string const &input,
   std::string output{"<!DOCTYPE html>\n<html>\n<head>\n"};
 
   if (!css_fn.empty()) {
-    output += R"(<link rel="stylesheet" type="text/css" href="file://)";
+    output += R"(<link rel="stylesheet" type="text/css" href="\screenplain.css)";
     output += css_fn;
     output += "\">\n";
   }
@@ -945,7 +945,7 @@ std::string ftn2textplay(std::string const &input, std::string const &css_fn) {
   std::string output{"<!DOCTYPE html>\n<html>\n<head>\n"};
 
   if (!css_fn.empty()) {
-    output += "<link rel=\"stylesheet\" type=\"text/css\" href=\"file://";
+    output += "<link rel=\"stylesheet\" type=\"text/css\" href=\"textplay.css>";
     output += css_fn;
     output += "\">\n";
   }
@@ -1126,7 +1126,7 @@ std::string ftn2xml(std::string const &input, std::string const &css_fn,
       output += css_contents;
       output += "\n</style>\n";
     } else {
-      output += "<link rel='stylesheet' type='text/css' href='file://";
+      output += "<link rel='stylesheet' type='text/css' href=fountain-xml.css";
       output += css_fn;
       output += "'>\n";
     }
@@ -1165,7 +1165,7 @@ std::string ftn2html(std::string const &input, std::string const &css_fn,
       output += css_contents;
       output += "\n</style>\n";
     } else {
-      output += "<link rel='stylesheet' type='text/css' href='file://";
+      output += "<link rel='stylesheet' type='text/css' href='fountain-html.css'";
       output += css_fn;
       output += "'>\n";
     }

--- a/src/fountain.h
+++ b/src/fountain.h
@@ -107,19 +107,19 @@ class Script {
 
 // html output compatible with screenplain css files
 std::string ftn2screenplain(std::string const &input,
-                            std::string const &css_fn = "");
+                            std::string const &css_fn = "screenplain.css");
 
 // html output compatible with textplay css files
 std::string ftn2textplay(std::string const &input,
-                         std::string const &css_fn = "");
+                         std::string const &css_fn = "textplay.css");
 
 // possibly compatible with finaldraft fdx files
 std::string ftn2fdx(std::string const &input);
 
 // native output; modern browsers can display with css
-std::string ftn2xml(std::string const &input, std::string const &css_fn = "",
+std::string ftn2xml(std::string const &input, std::string const &css_fn = "fountain-xml.css",
                     bool const &embed_css = true);
-std::string ftn2html(std::string const &input, std::string const &css_fn = "",
+std::string ftn2html(std::string const &input, std::string const &css_fn = "fountain-html.css",
                      bool const &embed_css = true);
 
 bool ftn2pdf(std::string const &fn, std::string const &input,


### PR DESCRIPTION
This is just the start of a few changes to make use of the css. ftn2xml and ftn2html did NOT use any of the css at all. Originally it said for css_fn which I concluded it means css_filename, it just said file:/// without any specification of which css file to use. I did a quick modification and it seems to work okay, absolutely needs further changes, so it's not ready yet in the current state.  For some reason, it works better when doing ftn2pdf instead of ftn2xml or ftn2html, but at least the html output even uses the css at all. It wasn't including external css file otherwise. Now, I previously made an issue opened that it did not respect scene heading numbering. Printing ftn2html to stdout, it seems that the fountain converter will instead of numbering the scene number, it decides like regular markdown to instead make it a h1 such as 'Sceneheaderh1' or whichever it was going by memory. This is a nice program, and just needs a bit of tweaking to be much better.

One additional thing to add, it currently is hardcoded to only use the css file that was named in the current directory. It would have to be changed so it can be more flexible on the css file location.